### PR TITLE
Fix unicode decode error if using umlauts in a filter.

### DIFF
--- a/Products/LDAPUserFolder/LDAPUserFolder.py
+++ b/Products/LDAPUserFolder/LDAPUserFolder.py
@@ -69,6 +69,12 @@ _dtmldir = os.path.join(package_home(globals()), 'dtml')
 EDIT_PERMISSION = 'Change user folder'
 
 
+def safe_utf8(s):
+    if isinstance(s, unicode):
+        s = s.encode('utf8')
+    return s
+
+
 class LDAPUserFolder(BasicUserFolder):
     """
         LDAPUserFolder
@@ -691,7 +697,7 @@ class LDAPUserFolder(BasicUserFolder):
         extra_filter = self.getProperty('_extra_user_filter')
         if extra_filter:
             user_filter_list.append(extra_filter)
-        user_filter = '(&%s)' % ''.join(user_filter_list)
+        user_filter = '(&%s)' % ''.join(map(safe_utf8, user_filter_list))
 
         return user_filter
 


### PR DESCRIPTION
user_filter_list is a list containing unicode values. The LDAP plugin needs utf-8 encoded strings and also the user-filter is encoded in utf-8.

So we just convert all values to utf-8 to have a clean state.

Take care, this error will not raise an error because it will just be ignored through a try/except block in the upper scope: https://github.com/zopefoundation/Products.PluggableAuthService/blob/1.11.1/Products/PluggableAuthService/PluggableAuthService.py#L320

Issue: https://github.com/4teamwork/opengever.core/issues/5983

<img width="346" alt="Bildschirmfoto 2019-10-30 um 16 44 31" src="https://user-images.githubusercontent.com/557005/67874024-a1a00200-fb34-11e9-872a-e018b6b0d123.png">

⚠️ There is no test. The provided buildout does not work. Even if we fix the buildout, the testsetup is completely broken and almost every test is failing.